### PR TITLE
🐛(utils) fix bugs in in_ensemble_similarity and consensus functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 Atheer A. "A closed patterns-based approach to the consensus clustering problem".
 Other [cs.OH]. Université Côte d’Azur, 2016. English. <NNT : 2016AZUR4111>. <tel-01478626>
+Retried from [tel.archives-ouvertes.fr](https://tel.archives-ouvertes.fr/tel-01478626)
 
 Atheer A., Pasquier N., Precioso F. "Using Closed Patterns to Solve the Consensus Clustering Problem".
 International Journal of Software Engineering and Knowledge Engineering 2016 26:09n10, 1379-1397

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,10 +23,10 @@ classifiers =
 [options]
 include_package_data = True
 install_requires =
-    numpy==1.21.4
-    pandas==1.3.4
+    numpy==1.22.3
+    pandas==1.4.2
     pyfim==6.28
-    scikit-learn==1.0.1
+    scikit-learn==1.0.2
 package_dir =
     =src
 packages = find:
@@ -35,12 +35,12 @@ python_requires = >= 3.9
 
 [options.extras_require]
 dev =
-    bandit==1.7.0
-    black==21.10b0
+    bandit==1.7.4
+    black==22.3.0
     flake8==4.0.1
-    isort==5.10.0
-    pylint==2.11.1
-    pytest==6.2.5
+    isort==5.10.1
+    pylint==2.13.7
+    pytest==7.1.2
     pytest-cov==3.0.0
 ci =
     twine==3.5.0

--- a/src/multicons/utils.py
+++ b/src/multicons/utils.py
@@ -21,8 +21,8 @@ def build_membership_matrix(base_clusterings: list[np.ndarray]) -> pd.DataFrame:
 def in_ensemble_similarity(base_clusterings: list[np.ndarray]) -> float:
     """Returns the average similarity among the base clusters using Jaccard score."""
 
-    if not base_clusterings or not isinstance(base_clusterings[0], np.ndarray):
-        raise IndexError("base_clusterings should contain at least one np.ndarray.")
+    if not base_clusterings or len(base_clusterings) < 2:
+        raise IndexError("base_clusterings should contain at least two np.ndarrays.")
 
     count = len(base_clusterings)
     index = np.arange(0, count)
@@ -32,10 +32,10 @@ def in_ensemble_similarity(base_clusterings: list[np.ndarray]) -> float:
         cluster_i = base_clusterings[i]
         for j in range(i + 1, count):
             cluster_j = base_clusterings[j]
-            similarity[i, j] = similarity[j, i] = jaccard_score(
-                cluster_i, cluster_j, average="weighted"
-            )
+            score = jaccard_score(cluster_i, cluster_j, average="weighted")
+            similarity.iloc[i, j] = similarity.iloc[j, i] = score
         average_similarity[i] = similarity.iloc[i].sum() / (count - 1)
+
     average_similarity[count - 1] = similarity.iloc[count - 1].sum() / (count - 1)
     return np.mean(average_similarity)
 
@@ -80,7 +80,7 @@ def consensus_function_10(bi_clust: list[np.ndarray]):
                     all_bi_clust_sets_unique = False
                     del bi_clust[i]
                     count -= 1
-                elif intersection_size == len(bi_clust_i):
+                elif intersection_size == len(bi_clust_j):
                     # Bj⊂Bi
                     all_bi_clust_sets_unique = False
                     del bi_clust[j]
@@ -110,7 +110,7 @@ def build_bi_clust(
     return result
 
 
-def multicons(base_clusterings):
+def multicons(base_clusterings: list[np.ndarray]):
     """Returns a dictionary with a list of consensus clustering vectors."""
 
     # 2 Calculate in-ensemble similarity

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -64,15 +64,17 @@ def test_build_membership_matrix_with_invalid_input(invalid):
 def test_in_ensemble_similarity():
     """Tests the in_ensemble_similarity should return the expected result."""
 
-    base_clusterings = [np.array([0, 1, 1]), np.array([1, 0, 0]), np.array([0, 1, 2])]
-    assert in_ensemble_similarity(base_clusterings) == 2 / 3
+    base_clusterings = [np.array([0, 1, 1]), np.array([1, 0, 2]), np.array([0, 1, 2])]
+    assert in_ensemble_similarity(base_clusterings) == 1 / 3
+    base_clusterings = [np.array([0, 1]), np.array([0, 1])]
+    assert in_ensemble_similarity(base_clusterings) == 1
 
 
 @pytest.mark.parametrize("invalid", ["", None, [], [[1, 2, 3]]])
 def test_in_ensemble_similarity_with_invalid_input(invalid):
     """Tests the in_ensemble_similarity raises an error on invalid input."""
 
-    error = "base_clusterings should contain at least one np.ndarray."
+    error = "base_clusterings should contain at least two np.ndarrays."
     with pytest.raises(IndexError, match=error):
         in_ensemble_similarity(invalid)
 


### PR DESCRIPTION
The `in_ensemble_similarity` function used a wrong matrix assignment
opreration leading to unexpected results.
The `consensus_function_10` function was not aligned with the original
algorithm pseudo-code.