### PR TITLE
✏️(readme) fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Atheer A. "A closed patterns-based approach to the consensus clustering problem".
 Other [cs.OH]. Université Côte d’Azur, 2016. English. <NNT : 2016AZUR4111>. <tel-01478626>
-Retried from [tel.archives-ouvertes.fr](https://tel.archives-ouvertes.fr/tel-01478626)
+Retrieved from [tel.archives-ouvertes.fr](https://tel.archives-ouvertes.fr/tel-01478626)
 
 Atheer A., Pasquier N., Precioso F. "Using Closed Patterns to Solve the Consensus Clustering Problem".
 International Journal of Software Engineering and Knowledge Engineering 2016 26:09n10, 1379-1397


### PR DESCRIPTION
"Retrieved" was wrongly spelled.