### PR TITLE
✅(tests) add test for the build_bi_clust function

### DIFF
--- a/src/multicons/utils.py
+++ b/src/multicons/utils.py
@@ -118,7 +118,7 @@ def multicons(base_clusterings: list[np.ndarray]):
     # 3 Build the cluster membership matrix M
     membership_matrix = build_membership_matrix(base_clusterings)
     # 4 Generate FCPs from M for minsupport = 0
-    # 5 Sort the FCPs in DESCENDING order according to the size of the instance sets
+    # 5 Sort the FCPs in ascending order according to the size of the instance sets
     frequent_closed_itemsets = linear_closed_itemsets_miner(membership_matrix)
     # 6 MaxDT ← length(BaseClusterings)
     max_d_t = len(base_clusterings)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,7 @@ from multicons import (
     linear_closed_itemsets_miner,
     multicons,
 )
+from multicons.utils import build_bi_clust
 
 
 def test_build_membership_matrix():
@@ -77,6 +78,31 @@ def test_in_ensemble_similarity_with_invalid_input(invalid):
     error = "base_clusterings should contain at least two np.ndarrays."
     with pytest.raises(IndexError, match=error):
         in_ensemble_similarity(invalid)
+
+
+def test_build_bi_clust():
+    """Tests the build_bi_clust function."""
+
+    membership_matrix = pd.DataFrame(
+        [
+            [1, 0, 0, 1],
+            [1, 0, 1, 0],
+            [0, 1, 1, 0],
+            [0, 1, 1, 0],
+        ],
+        columns=["A", "B", "C", "D"],
+    )
+    frequent_closed_itemsets = [
+        frozenset(["A", "C"]),
+        frozenset(["B", "C"]),
+        frozenset(["A", "D"]),
+        frozenset(["A", "B", "C"]),
+    ]
+    assert build_bi_clust(membership_matrix, frequent_closed_itemsets, 2) == [
+        set([1]),
+        set([2, 3]),
+        set([0]),
+    ]
 
 
 def test_linear_closed_itemsets_miner():


### PR DESCRIPTION
Although other tests cover the `build_bi_clust` function, it might be
insightful to test it separately.