### PR TITLE
🐛(utils) correct jaccard similarity measure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY . /app/
 
 RUN pip install -e .[dev]
 
-RUN jupyter nbextension install --py jupytext && \
-    jupyter nbextension enable --py jupytext
+RUN jupyter nbextension install jupytext --py && \
+    jupyter nbextension enable jupytext --py
 
 USER ${DOCKER_USER:-1000}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,11 +11,7 @@ from multicons import (
     linear_closed_itemsets_miner,
     multicons,
 )
-from multicons.utils import (
-    build_bi_clust,
-    ensemble_jaccard_score,
-    sklearn_jaccard_score,
-)
+from multicons.utils import build_bi_clust, ensemble_jaccard_score
 
 
 def test_build_membership_matrix():
@@ -71,7 +67,7 @@ def test_in_ensemble_similarity():
     """Tests the in_ensemble_similarity should return the expected result."""
 
     base_clusterings = [np.array([0, 1, 1]), np.array([1, 0, 2]), np.array([0, 1, 2])]
-    assert in_ensemble_similarity(base_clusterings) == 1 / 3
+    assert in_ensemble_similarity(base_clusterings) - 0.233 < 0.001
     base_clusterings = [np.array([0, 1]), np.array([0, 1])]
     assert in_ensemble_similarity(base_clusterings) == 1
 
@@ -155,8 +151,8 @@ def test_linear_closed_itemsets_miner():
     assert linear_closed_itemsets_miner(membership_matrix) == expected
 
 
-def test_multicons():
-    """Tests the multicons function."""
+def test_multicons_without_any_parameters_using_jaccard_similarity():
+    """Tests the multicons function without passing any optional parameters."""
 
     base_clusterings = [
         np.array([0, 0, 0, 1, 1, 1, 1, 1, 1]),
@@ -165,27 +161,7 @@ def test_multicons():
         np.array([1, 1, 1, 0, 0, 0, 0, 2, 2]),
         np.array([1, 1, 1, 0, 0, 0, 0, 2, 2]),
     ]
-    # Using sklearn_jaccard_score
-    value = multicons(base_clusterings, similarity_measure=sklearn_jaccard_score)
-    expected_consensus = np.array(
-        [
-            np.array([1, 1, 1, 1, 1, 1, 1, 1, 1]),
-            np.array([0, 0, 0, 1, 1, 1, 1, 1, 1]),
-            np.array([0, 0, 0, 1, 1, 1, 1, 2, 2]),
-            np.array([0, 0, 0, 3, 3, 1, 1, 2, 2]),
-        ]
-    )
-    expected_similarity = np.array([0.44444444, 0.48444444, 0.46962963, 0.38074074])
-    assert value["recommended"] == 1
-    np.testing.assert_array_equal(value["consensus_vectors"], expected_consensus)
-    similarity = value["ensemble_similarity"]
-    assert (np.absolute(similarity - expected_similarity) < 0.0000001).all()
-    assert value["tree_quality"] == 1
-    np.testing.assert_array_equal(value["decision_thresholds"], np.array([1, 2, 4, 5]))
-    np.testing.assert_array_equal(value["stability"], np.array([1, 1, 2, 1]))
-
-    # Using ensemble_jaccard_score
-    value = multicons(base_clusterings, similarity_measure=ensemble_jaccard_score)
+    value = multicons(base_clusterings)
     expected_consensus = np.array(
         [
             np.array([0, 0, 0, 0, 0, 0, 0, 0, 0]),
@@ -194,13 +170,86 @@ def test_multicons():
             np.array([1, 1, 1, 0, 0, 2, 2, 3, 3]),
         ]
     )
-    expected_similarity = np.array([0.16666667, 0.72355556, 0.86, 0.78095238])
-    # Check that the ensemble_jaccard_score is the default.
-    default_value = multicons(base_clusterings)
-    np.testing.assert_array_equal(
-        value["ensemble_similarity"], default_value["ensemble_similarity"]
-    )
+    np.testing.assert_array_equal(value["consensus_vectors"], expected_consensus)
+    expected_similarity = np.array([0.37777778, 0.67222222, 0.69722222, 0.47333333])
+    similarity = value["ensemble_similarity"]
+    assert (np.absolute(similarity - expected_similarity) < 0.0000001).all()
     assert value["recommended"] == 2
+    assert value["tree_quality"] == 1
+    np.testing.assert_array_equal(value["decision_thresholds"], np.array([1, 2, 4, 5]))
+    np.testing.assert_array_equal(value["stability"], np.array([1, 1, 2, 1]))
+
+    # Given a membership matrix and clusterings_count instead of base_clusterings
+    # Should produce the same result.
+    membership_matrix = build_membership_matrix(base_clusterings)
+    membership_value = multicons(
+        membership_matrix, is_membership_matrix=True, clusterings_count=5
+    )
+    np.testing.assert_array_equal(
+        membership_value["consensus_vectors"], value["consensus_vectors"]
+    )
+
+
+def test_multicons_with_jaccard_index_similarity_measure():
+    """Tests the multicons function with `similarity_measure="JaccardIndex"` and
+    `optimize_label_names=True`.
+    """
+
+    base_clusterings = [
+        np.array([0, 0, 0, 1, 1, 1, 1, 1, 1]),
+        np.array([0, 0, 0, 1, 1, 1, 1, 1, 1]),
+        np.array([0, 0, 0, 0, 0, 1, 1, 2, 2]),
+        np.array([1, 1, 1, 0, 0, 0, 0, 2, 2]),
+        np.array([1, 1, 1, 0, 0, 0, 0, 2, 2]),
+    ]
+    value = multicons(
+        base_clusterings, similarity_measure="JaccardIndex", optimize_label_names=True
+    )
+    expected_consensus = np.array(
+        [
+            np.array([1, 1, 1, 1, 1, 1, 1, 1, 1]),
+            np.array([0, 0, 0, 1, 1, 1, 1, 1, 1]),
+            np.array([0, 0, 0, 1, 1, 1, 1, 2, 2]),
+            np.array([0, 0, 0, 3, 3, 1, 1, 2, 2]),
+        ]
+    )
+    np.testing.assert_array_equal(value["consensus_vectors"], expected_consensus)
+    expected_similarity = np.array([0.305, 0.47692308, 0.43181818, 0.33111888])
+    similarity = value["ensemble_similarity"]
+    assert (np.absolute(similarity - expected_similarity) < 0.0000001).all()
+    assert value["recommended"] == 1
+    assert value["tree_quality"] == 1
+    np.testing.assert_array_equal(value["decision_thresholds"], np.array([1, 2, 4, 5]))
+    np.testing.assert_array_equal(value["stability"], np.array([1, 1, 2, 1]))
+
+
+def test_multicons_with_ensemble_jaccard_score_similarity_measure():
+    """Tests the multicons function with `similarity_measure=ensemble_jaccard_score` and
+    `optimize_label_names=True`.
+    """
+
+    base_clusterings = [
+        np.array([0, 0, 0, 1, 1, 1, 1, 1, 1]),
+        np.array([0, 0, 0, 1, 1, 1, 1, 1, 1]),
+        np.array([0, 0, 0, 0, 0, 1, 1, 2, 2]),
+        np.array([1, 1, 1, 0, 0, 0, 0, 2, 2]),
+        np.array([1, 1, 1, 0, 0, 0, 0, 2, 2]),
+    ]
+    value = multicons(
+        base_clusterings,
+        similarity_measure=ensemble_jaccard_score,
+        optimize_label_names=True,
+    )
+    expected_consensus = np.array(
+        [
+            np.array([0, 0, 0, 0, 0, 0, 0, 0, 0]),
+            np.array([0, 0, 0, 1, 1, 1, 1, 1, 1]),
+            np.array([0, 0, 0, 2, 2, 2, 2, 1, 1]),
+            np.array([1, 1, 1, 0, 0, 2, 2, 3, 3]),
+        ]
+    )
+    expected_similarity = np.array([[0.55555556, 0.82666667, 0.80666667, 0.65]])
+    assert value["recommended"] == 1
     np.testing.assert_array_equal(value["consensus_vectors"], expected_consensus)
     similarity = value["ensemble_similarity"]
     assert (np.absolute(similarity - expected_similarity) < 0.0000001).all()
@@ -219,53 +268,51 @@ def test_cons_tree():
         np.array([1, 1, 1, 0, 0, 0, 0, 2, 2]),
         np.array([1, 1, 1, 0, 0, 0, 0, 2, 2]),
     ]
-    tree = cons_tree(
-        multicons(base_clusterings, similarity_measure=sklearn_jaccard_score)
-    )
+    tree = cons_tree(multicons(base_clusterings))
     assert str(tree).split("\n") == [
         "digraph {",
         '\tgraph [label="ConsTree',
         'Tree Quality = 1.0" labelloc=t]',
         "\tnode [fillcolor=slategray2 shape=ellipse style=filled width=9]",
-        "\t01 [label=9]",
+        "\t00 [label=9]",
         "\tsubgraph cluster {",
         "\t\tgraph [label=Legend]",
         '\t\tnode [shape=box width=""]',
-        '\t\tlegend_0 [label="DT=1 ST=1 Similarity=0.44"]',
-        "\t}",
-        "\tnode [fillcolor=darkseagreen shape=box style=filled width=3]",
-        "\t10 [label=3]",
-        "\t01 -> 10",
-        "\tnode [fillcolor=darkseagreen shape=box style=filled width=6]",
-        "\t11 [label=6]",
-        "\t01 -> 11",
-        "\tsubgraph cluster {",
-        "\t\tgraph [label=Legend]",
-        '\t\tnode [shape=box width=""]',
-        '\t\tlegend_1 [label="DT=2 ST=1 Similarity=0.48"]',
-        "\t\tlegend_0 -> legend_1",
+        '\t\tlegend_0 [label="DT=1 ST=1 Similarity=0.38"]',
         "\t}",
         "\tnode [fillcolor=slategray2 shape=ellipse style=filled width=3]",
+        "\t10 [label=3]",
+        "\t00 -> 10",
+        "\tnode [fillcolor=slategray2 shape=ellipse style=filled width=6]",
+        "\t11 [label=6]",
+        "\t00 -> 11",
+        "\tsubgraph cluster {",
+        "\t\tgraph [label=Legend]",
+        '\t\tnode [shape=box width=""]',
+        '\t\tlegend_1 [label="DT=2 ST=1 Similarity=0.67"]',
+        "\t\tlegend_0 -> legend_1",
+        "\t}",
+        "\tnode [fillcolor=darkseagreen shape=box style=filled width=3]",
         "\t20 [label=3]",
         "\t10 -> 20",
-        "\tnode [fillcolor=slategray2 shape=ellipse style=filled width=4]",
-        "\t21 [label=4]",
+        "\tnode [fillcolor=darkseagreen shape=box style=filled width=2]",
+        "\t21 [label=2]",
         "\t11 -> 21",
-        "\tnode [fillcolor=slategray2 shape=ellipse style=filled width=2]",
-        "\t22 [label=2]",
+        "\tnode [fillcolor=darkseagreen shape=box style=filled width=4]",
+        "\t22 [label=4]",
         "\t11 -> 22",
         "\tsubgraph cluster {",
         "\t\tgraph [label=Legend]",
         '\t\tnode [shape=box width=""]',
-        '\t\tlegend_2 [label="DT=4 ST=2 Similarity=0.47"]',
+        '\t\tlegend_2 [label="DT=4 ST=2 Similarity=0.7"]',
         "\t\tlegend_1 -> legend_2",
         "\t}",
-        "\tnode [fillcolor=slategray2 shape=ellipse style=filled width=3]",
-        "\t30 [label=3]",
-        "\t20 -> 30",
         "\tnode [fillcolor=slategray2 shape=ellipse style=filled width=2]",
-        "\t31 [label=2]",
-        "\t21 -> 31",
+        "\t30 [label=2]",
+        "\t22 -> 30",
+        "\tnode [fillcolor=slategray2 shape=ellipse style=filled width=3]",
+        "\t31 [label=3]",
+        "\t20 -> 31",
         "\tnode [fillcolor=slategray2 shape=ellipse style=filled width=2]",
         "\t32 [label=2]",
         "\t22 -> 32",
@@ -275,7 +322,7 @@ def test_cons_tree():
         "\tsubgraph cluster {",
         "\t\tgraph [label=Legend]",
         '\t\tnode [shape=box width=""]',
-        '\t\tlegend_3 [label="DT=5 ST=1 Similarity=0.38"]',
+        '\t\tlegend_3 [label="DT=5 ST=1 Similarity=0.47"]',
         "\t\tlegend_2 -> legend_3",
         "\t}",
         "}",


### PR DESCRIPTION
The jaccard similarity measure was incorrect.
We used previously the ensemble formula by default:
|X ∩ Y| / (|X| + |Y| - |X ∩ Y|

However, the multicons implementation requires the
pair-wise jaccard similarity measure which is computed
with the following formula:
yy / (yy + ny + yn)

Where:
`yy` is number of times two points belong to same cluster in both
partitions.
`ny` and `yn` are the number of times two points belong to the same
cluster in one partition but not in the other.