### PR TITLE
🐛(utils) use boolean type for membership matrix

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -22,3 +22,12 @@ from multicons import (
         - linear_closed_itemsets_miner
     rendering:
         show_root_heading: true
+
+
+```python
+from multicons import consensus_function_10
+```
+
+::: multicons.consensus
+    rendering:
+        show_root_heading: true

--- a/docs/examples.py
+++ b/docs/examples.py
@@ -97,7 +97,7 @@ cassini_train_data.plot.scatter(
 )
 
 # C-means
-fcm = FCM(n_clusters=3, max_iter=8, m=10)
+fcm = FCM(n_clusters=3, max_iter=5, m=5)
 fcm.fit(cassini_train_data.values)
 base_clusterings.append(fcm.predict(cassini_train_data.values))
 cassini_train_data.plot.scatter(
@@ -111,7 +111,7 @@ cassini_train_data.plot.scatter(
 )
 
 # BIRCH
-birch = Birch(n_clusters=3, threshold=0.7)
+birch = Birch(n_clusters=3, threshold=0.5)
 base_clusterings.append(birch.fit_predict(cassini_train_data))
 cassini_train_data.plot.scatter(
     title="BIRCH", ax=axes[2, 0], c=base_clusterings[-1], **common_kwargs
@@ -204,8 +204,8 @@ cons_tree = consensus.cons_tree()
 cons_tree
 
 # %%
-# Save the graph to a file
+# Save the ConsTree graph to a file
 cons_tree.render(outfile=f"{file_prefix}CassiniConsTree.svg", cleanup=True)
 
 # %% [markdown]
-# The graph in full size: [CassiniConsTree.svg](../CassiniConsTree.svg)
+# View ConsTree graph in full size: [CassiniConsTree.svg](../CassiniConsTree.svg)

--- a/src/multicons/__init__.py
+++ b/src/multicons/__init__.py
@@ -2,6 +2,7 @@
 
 # flake8: noqa
 
+from multicons.consensus import consensus_function_10
 from multicons.core import MultiCons
 from multicons.utils import (
     build_membership_matrix,

--- a/src/multicons/consensus.py
+++ b/src/multicons/consensus.py
@@ -4,32 +4,31 @@
 def consensus_function_10(bi_clust: list[set]):
     """Returns a modified bi_clust (set of unique instance sets)."""
 
-    all_bi_clust_sets_unique = False
-    while not all_bi_clust_sets_unique:
-        all_bi_clust_sets_unique = True
-        i = 0
-        count = len(bi_clust)
-        while i < count:
-            bi_clust_i = bi_clust[i]
-            j = i + 1
-            while j < count:
-                bi_clust_j = bi_clust[j]
-                intersection_size = len(bi_clust_i.intersection(bi_clust_j))
-                if intersection_size == 0:
-                    j += 1
-                elif intersection_size == len(bi_clust_i):
-                    # Bi⊂Bj
-                    all_bi_clust_sets_unique = False
-                    del bi_clust[i]
-                    count -= 1
-                elif intersection_size == len(bi_clust_j):
-                    # Bj⊂Bi
-                    all_bi_clust_sets_unique = False
-                    del bi_clust[j]
-                    count -= 1
-                else:
-                    bi_clust[j] = bi_clust_i.union(bi_clust_j)
-                    all_bi_clust_sets_unique = False
-                    del bi_clust[i]
-                    count -= 1
-            i += 1
+    i = 0
+    count = len(bi_clust)
+    while i < count:
+        bi_clust_i = bi_clust[i]
+        j = i + 1
+        while j < count:
+            bi_clust_j = bi_clust[j]
+            intersection_size = len(bi_clust_i.intersection(bi_clust_j))
+            if intersection_size == 0:
+                j += 1
+                continue
+            if intersection_size == len(bi_clust_i):
+                # Bi⊂Bj
+                del bi_clust[i]
+                count -= 1
+                i -= 1
+                break
+            if intersection_size == len(bi_clust_j):
+                # Bj⊂Bi
+                del bi_clust[j]
+                count -= 1
+                continue
+            bi_clust[j] = bi_clust_i.union(bi_clust_j)
+            del bi_clust[i]
+            count -= 1
+            i -= 1
+            break
+        i += 1

--- a/src/multicons/core.py
+++ b/src/multicons/core.py
@@ -156,7 +156,7 @@ class MultiCons(BaseEstimator):
         # 5 Sort the FCPs in ascending order according to the size of the instance sets
         frequent_closed_itemsets = linear_closed_itemsets_miner(membership_matrix)
         # 6 MaxDT ← length(BaseClusterings)
-        max_d_t = (membership_matrix.iloc[0] == 1).sum()
+        max_d_t = (membership_matrix.iloc[0]).sum()
         # 7 BiClust ← {instance sets of FCPs built from MaxDT base clusters}
         bi_clust = build_bi_clust(membership_matrix, frequent_closed_itemsets, max_d_t)
         # 8 Assign a label to each set in BiClust to build the first consensus vector

--- a/src/multicons/core.py
+++ b/src/multicons/core.py
@@ -10,6 +10,7 @@ from sklearn.base import BaseEstimator
 
 from .consensus import consensus_function_10
 from .utils import (
+    build_base_clusterings,
     build_bi_clust,
     build_membership_matrix,
     jaccard_index,
@@ -144,7 +145,8 @@ class MultiCons(BaseEstimator):
         """
 
         if isinstance(X, pd.DataFrame):
-            membership_matrix = X
+            membership_matrix = pd.DataFrame(X, dtype=bool)
+            X = build_base_clusterings(X)
         else:
             X = np.array(X, dtype=int)
             # 2 Calculate in-ensemble similarity
@@ -156,7 +158,7 @@ class MultiCons(BaseEstimator):
         # 5 Sort the FCPs in ascending order according to the size of the instance sets
         frequent_closed_itemsets = linear_closed_itemsets_miner(membership_matrix)
         # 6 MaxDT ← length(BaseClusterings)
-        max_d_t = (membership_matrix.iloc[0]).sum()
+        max_d_t = len(X)
         # 7 BiClust ← {instance sets of FCPs built from MaxDT base clusters}
         bi_clust = build_bi_clust(membership_matrix, frequent_closed_itemsets, max_d_t)
         # 8 Assign a label to each set in BiClust to build the first consensus vector

--- a/src/multicons/utils.py
+++ b/src/multicons/utils.py
@@ -71,7 +71,7 @@ def build_membership_matrix(base_clusterings: np.ndarray) -> pd.DataFrame:
     res = []
     for clusters in base_clusterings:
         res += [clusters == x for x in np.unique(clusters)]
-    return pd.DataFrame(np.transpose(res), dtype=int)
+    return pd.DataFrame(np.transpose(res), dtype=bool)
 
 
 def build_bi_clust(

--- a/src/multicons/utils.py
+++ b/src/multicons/utils.py
@@ -74,6 +74,25 @@ def build_membership_matrix(base_clusterings: np.ndarray) -> pd.DataFrame:
     return pd.DataFrame(np.transpose(res), dtype=bool)
 
 
+def build_base_clusterings(membership_matrix: pd.DataFrame) -> np.ndarray:
+    """Computes and returns the base_clusterings."""
+
+    clusters_count = (membership_matrix.iloc[0]).sum()
+    cluster_size = membership_matrix.shape[0]
+    base_clusterings = np.zeros((clusters_count, cluster_size), dtype=int)
+    column = 0
+    for i in range(clusters_count):
+        items_count = 0
+        label = 0
+        while items_count < cluster_size:
+            items = np.nonzero(membership_matrix.iloc[:, column].values)[0]
+            base_clusterings[i][items] = label
+            items_count += items.size
+            column += 1
+            label += 1
+    return base_clusterings
+
+
 def build_bi_clust(
     membership_matrix: pd.DataFrame,
     frequent_closed_itemsets: list[frozenset],
@@ -86,7 +105,7 @@ def build_bi_clust(
     for itemset in itemsets:
         consensus = np.ones(len(membership_matrix), dtype=bool)
         for partition in itemset:
-            consensus = consensus & membership_matrix[partition]
+            consensus = consensus & membership_matrix.iloc[:, partition]
         result.append(set(consensus[consensus].index.values))
     return result
 

--- a/tests/test_consensus.py
+++ b/tests/test_consensus.py
@@ -1,0 +1,24 @@
+"""Tests for consensus functions"""
+
+import pytest
+
+from multicons import consensus_function_10
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        # A unique cluster remains unique
+        ([{1}], [{1}]),
+        # Clusters that are subsets are removed
+        ([{1, 2}, {1}], [{1, 2}]),
+        ([{1, 2}, {1, 2, 3}], [{1, 2, 3}]),
+        # Clusters that are intersections are merged
+        ([{1, 2, 3}, {2, 3, 4}, {5}], [{1, 2, 3, 4}, {5}]),
+    ],
+)
+def test_consensus_consensus_function_10(value, expected):
+    """Tests the consensus_function_10 should produce the expected value."""
+
+    consensus_function_10(value)
+    assert value == expected

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,7 +7,7 @@ from multicons import MultiCons, build_membership_matrix
 from multicons.utils import ensemble_jaccard_score
 
 
-def test_cre_multicons_with_invalid_parameters():
+def test_core_multicons_with_invalid_parameters():
     """Tests that the MultiCons class raises an Exception given invalid parameters."""
 
     with pytest.raises(ValueError, match="Invalid value"):
@@ -47,6 +47,9 @@ def test_core_multicons_without_any_parameters_using_jaccard_similarity():
     membership_value = MultiCons().fit(membership_matrix)
     np.testing.assert_array_equal(
         membership_value.consensus_vectors, value.consensus_vectors
+    )
+    np.testing.assert_array_equal(
+        membership_value.ensemble_similarity, value.ensemble_similarity
     )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,7 @@ from multicons import (
     in_ensemble_similarity,
     linear_closed_itemsets_miner,
 )
-from multicons.utils import build_bi_clust
+from multicons.utils import build_base_clusterings, build_bi_clust
 
 
 def test_utils_build_membership_matrix():
@@ -61,6 +61,50 @@ def test_utils_build_membership_matrix_with_invalid_input(invalid):
     error = "base_clusterings should contain at least one np.ndarray."
     with pytest.raises(IndexError, match=error):
         build_membership_matrix(invalid)
+
+
+def test_utils_build_base_clusterings():
+    """Tests the build_base_clusterings should return the expected result."""
+
+    membership_matrix = pd.DataFrame(
+        [
+            [1, 0, 0, 1, 1, 0, 0],
+            [0, 1, 1, 0, 0, 1, 0],
+            [0, 1, 1, 0, 0, 0, 1],
+        ],
+        columns=list(range(7)),
+        dtype=bool,
+    )
+    value = build_base_clusterings(membership_matrix)
+    expected = np.array([np.array([0, 1, 1]), np.array([1, 0, 0]), np.array([0, 1, 2])])
+    np.testing.assert_array_equal(value, expected)
+
+    membership_matrix = pd.DataFrame(
+        [
+            [1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0],
+            [1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0],
+            [1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0],
+            [0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 0],
+            [0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 0],
+            [0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 0],
+            [0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 0],
+            [0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1],
+            [0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1],
+        ],
+        columns=list(range(13)),
+        dtype=bool,
+    )
+    value = build_base_clusterings(membership_matrix)
+    expected = np.array(
+        [
+            np.array([0, 0, 0, 1, 1, 1, 1, 1, 1]),
+            np.array([0, 0, 0, 1, 1, 1, 1, 1, 1]),
+            np.array([0, 0, 0, 0, 0, 1, 1, 2, 2]),
+            np.array([1, 1, 1, 0, 0, 0, 0, 2, 2]),
+            np.array([1, 1, 1, 0, 0, 0, 0, 2, 2]),
+        ]
+    )
+    np.testing.assert_array_equal(value, expected)
 
 
 def test_utils_in_ensemble_similarity():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,6 +24,7 @@ def test_utils_build_membership_matrix():
             [0, 1, 1, 0, 0, 0, 1],
         ],
         columns=list(range(7)),
+        dtype=bool,
     )
     pd.testing.assert_frame_equal(value, expected)
 
@@ -48,6 +49,7 @@ def test_utils_build_membership_matrix():
             [0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1],
         ],
         columns=list(range(13)),
+        dtype=bool,
     )
     pd.testing.assert_frame_equal(value, expected)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -92,13 +92,16 @@ def test_utils_build_bi_clust():
             [0, 1, 1, 0],
         ],
         columns=["A", "B", "C", "D"],
+        dtype=bool,
     )
     frequent_closed_itemsets = [
-        frozenset(["A", "C"]),
-        frozenset(["B", "C"]),
-        frozenset(["A", "D"]),
-        frozenset(["A", "B", "C"]),
+        frozenset({2}),
+        frozenset({0}),
+        frozenset({0, 2}),
+        frozenset({1, 2}),
+        frozenset({0, 3}),
     ]
+    assert frequent_closed_itemsets == linear_closed_itemsets_miner(membership_matrix)
     assert build_bi_clust(membership_matrix, frequent_closed_itemsets, 2) == [
         set([1]),
         set([2, 3]),


### PR DESCRIPTION
It is more convenient to use boolean type for the membership matrix.
This should avoid having to convert between integer and boolean types.