### PR TITLE
⬆️(project) upgrade python dependencies

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -466,6 +466,5 @@ min-public-methods=0
 
 [EXCEPTIONS]
 
-# Exceptions that will emit a warning when being caught. Defaults to
-# "Exception"
-overgeneral-exceptions=Exception
+# Exceptions that will emit a warning when being caught.
+overgeneral-exceptions=builtins.Exception

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,7 @@ and this project adheres to
 
 ### Changed
 
-- Upgrade `numpy` to `1.22.4`
-- Upgrade `scikit-learn` to `1.1.1 `
-- Upgrade `jupyterlab` to `3.4.3 `
-- Upgrade `mkdocs-jupyter` to `0.21.0`
-- Upgrade `mkdocs-material` to `8.3.4 `
-- Upgrade `mkdocstrings` to `0.19.0`
-- Upgrade `pylint` to `2.14.1`
-- Upgrade `twine` to `4.0.1 `
+- Improve library usage of MultiCons by unpinning dependencies
 
 ## [0.1.0] - 2022-05-18
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # -- Base image --
-FROM python:3.9-slim-bullseye as base
+FROM python:3.10-slim-bullseye as base
 
 RUN pip install --upgrade pip
 
@@ -17,7 +17,8 @@ COPY . /app/
 
 RUN pip install -e .[dev]
 
-RUN jupyter nbextension install jupytext --py && \
-    jupyter nbextension enable jupytext --py
+RUN jupyter contrib nbextension install && \
+   jupyter nbextension install jupytext --py && \
+   jupyter nbextension enable jupytext --py
 
 USER ${DOCKER_USER:-1000}

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 DOCKER_UID           = $(shell id -u)
 DOCKER_GID           = $(shell id -g)
 DOCKER_USER          = $(DOCKER_UID):$(DOCKER_GID)
-COMPOSE              = DOCKER_USER=$(DOCKER_USER) docker-compose
+COMPOSE              = DOCKER_USER=$(DOCKER_USER) docker compose
 COMPOSE_RUN          = $(COMPOSE) run --rm
 COMPOSE_RUN_APP      = $(COMPOSE_RUN) app
 MKDOCS               = $(COMPOSE_RUN) -e HOME=/app/.jupyterlab --publish "8000:8000" app mkdocs

--- a/bin/pytest
+++ b/bin/pytest
@@ -3,4 +3,4 @@
 declare DOCKER_USER
 DOCKER_USER="$(id -u):$(id -g)"
 
-DOCKER_USER=${DOCKER_USER} docker-compose run --rm app pytest "$@"
+DOCKER_USER=${DOCKER_USER} docker compose run --rm app pytest "$@"

--- a/gitlint/gitlint_emoji.py
+++ b/gitlint/gitlint_emoji.py
@@ -30,7 +30,7 @@ class GitmojiTitle(LineRule):
         repository and check that title contains one of them.
         """
         gitmojis = requests.get(
-            "https://raw.githubusercontent.com/carloscuesta/gitmoji/master/src/data/gitmojis.json"  # noqa
+            "https://raw.githubusercontent.com/carloscuesta/gitmoji/master/packages/gitmojis/src/gitmojis.json"  # noqa
         ).json()["gitmojis"]
         emojis = [item["emoji"] for item in gitmojis]
         pattern = r"^({:s})\(.*\)\s[a-z].*$".format("|".join(emojis))

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,11 +23,11 @@ classifiers =
 [options]
 include_package_data = True
 install_requires =
-    graphviz==0.20
-    numpy==1.22.4
-    pandas==1.4.2
-    pyfim==6.28
-    scikit-learn==1.1.1
+    graphviz>=0.20
+    numpy>=1.24.0
+    pandas>=2.0.0
+    pyfim>=6.28
+    scikit-learn>=1.2.0
 package_dir =
     =src
 packages = find:
@@ -36,24 +36,25 @@ python_requires = >= 3.9
 
 [options.extras_require]
 dev =
-    bandit==1.7.4
-    black==22.3.0
-    flake8==4.0.1
-    fuzzy-c-means==1.6.4
-    isort==5.10.1
-    jupyterlab==3.4.3
-    jupytext==1.13.8
-    matplotlib==3.5.2
-    mkdocs==1.3.0
-    mkdocs-jupyter==0.21.0
-    mkdocs-material==8.3.4
-    mkdocstrings[python]==0.19.0
-    pylint==2.14.1
-    pytest==7.1.2
-    pytest-cov==3.0.0
-    scikit-learn-extra==0.2.0
+    bandit==1.7.5
+    black==23.3.0
+    flake8==6.0.0
+    fuzzy-c-means==1.7.0
+    isort==5.12.0
+    jupyterlab==3.6.3
+    jupyter_contrib_nbextensions==0.7.0
+    jupytext==1.14.5
+    matplotlib==3.7.1
+    mkdocs==1.4.2
+    mkdocs-jupyter==0.24.1
+    mkdocs-material==9.1.6
+    mkdocstrings[python]==0.21.2
+    pylint==2.17.2
+    pytest==7.3.0
+    pytest-cov==4.0.0
+    scikit-learn-extra==0.3.0
 ci =
-    twine==4.0.1
+    twine==4.0.2
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
As this project is intended to be used as a library, we need to
relax the primary dependencies version constraints:

| package     | from   | to       |
|-------------|--------|----------|
|graphviz     | 0.20   | >=0.20   |
|numpy        | 1.22.4 | >=1.24.0 |
|pandas       | 1.4.2  | >=2.0.0  |
|pyfim        | 6.28   | >=6.28   |
|scikit-learn | 1.1.1  | >=1.2.0  |

We also upgrade the following packages used in dev/ci environments:

| package                     | from    | to     |
|-----------------------------|---------|--------|
|bandit                       | 1.7.4   | 1.7.5  |
|black                        | 22.3.0  | 23.3.0 |
|flake8                       | 4.0.1   | 6.0.0  |
|fuzzy-c-means                | 1.6.4   | 1.7.0  |
|isort                        | 5.10.1  | 5.12.0 |
|jupyterlab                   | 3.4.3   | 3.6.3  |
|jupytext                     | 1.13.8  | 0.7.0  |
|jupyter_contrib_nbextensions |         | 1.14.5 |
|matplotlib                   | 3.5.2   | 3.7.1  |
|mkdocs                       | 1.3.0   | 1.4.2  |
|mkdocs-jupyter               | 0.21.0  | 0.24.1 |
|mkdocs-material              | 8.3.4   | 9.1.6  |
|mkdocstrings[python]         | 0.19.0  | 0.21.2 |
|pylint                       | 2.14.1  | 2.17.2 |
|pytest                       | 7.1.2   | 7.3.0  |
|pytest-cov                   | 3.0.0   | 4.0.0  |
|scikit-learn-extra           | 0.2.0   | 0.3.0  |
|twine                        | 4.0.1   | 4.0.2  |