### PR TITLE
📝(project) fix broken links in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,6 @@ and this project adheres to
 
 - Implement the MultiCons class
 
-[unreleased]: https://github.com/SergioSim/multicons/v0.2.0...master
-[0.2.0]: https://github.com/SergioSim/multicons/v0.1.0...v0.2.0
+[unreleased]: https://github.com/SergioSim/multicons/compare/v0.2.0...master
+[0.2.0]: https://github.com/SergioSim/multicons/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/SergioSim/multicons/compare/125c67d...v0.1.0


### PR DESCRIPTION
The links in the CHANGELOG.md used to compare changes between releases needed to be corrected.