### PR TITLE
🐛(consensus) fix incompatible dtype warning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   # Check that the git history is clean and complies with our expectations
   lint-git:
     docker:
-      - image: circleci/python:3.9-buster
+      - image: cimg/python:3.12.3
     working_directory: ~/multicons
     steps:
       # Checkout repository sources
@@ -23,7 +23,7 @@ jobs:
       - run:
           name: Install gitlint
           command: |
-            pip install --user gitlint
+            pip install --user gitlint requests
       - run:
           name: lint commit messages added to master
           command: |
@@ -32,7 +32,7 @@ jobs:
   # Build the package
   build:
     docker:
-      - image: cimg/python:3.10.0
+      - image: cimg/python:3.12.3
     working_directory: ~/multicons
     steps:
       # Checkout repository sources
@@ -48,7 +48,7 @@ jobs:
   # Build documentation
   build-docs:
     docker:
-      - image: cimg/python:3.10.0
+      - image: cimg/python:3.12.3
     working_directory: ~/multicons
     steps:
       - checkout
@@ -62,7 +62,7 @@ jobs:
   # Deploy documentation to GitHub pages
   deploy-docs:
     docker:
-      - image: cimg/python:3.10.0
+      - image: cimg/python:3.12.3
     working_directory: ~/multicons
     steps:
       - checkout
@@ -86,7 +86,7 @@ jobs:
   # Lint source code
   lint:
     docker:
-      - image: cimg/python:3.10.0
+      - image: cimg/python:3.12.3
     working_directory: ~/multicons
     steps:
       # Checkout repository sources
@@ -113,7 +113,7 @@ jobs:
   # Package project
   package:
     docker:
-      - image: cimg/python:3.10.0
+      - image: cimg/python:3.12.3
     working_directory: ~/multicons
     steps:
       - checkout
@@ -137,7 +137,7 @@ jobs:
   #     environment variables in CircleCI UI (with your PyPI credentials)
   pypi:
     docker:
-      - image: cimg/python:3.10.0
+      - image: cimg/python:3.12.3
     working_directory: ~/multicons
     steps:
       - checkout
@@ -157,7 +157,7 @@ jobs:
   # Run tests
   test:
     docker:
-      - image: cimg/python:3.10.0
+      - image: cimg/python:3.12.3
     working_directory: ~/multicons
     steps:
       # Checkout repository sources

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # -- Base image --
-FROM python:3.10-slim-bullseye as base
+FROM python:3.12-slim-bullseye as base
 
 RUN pip install --upgrade pip
 
@@ -16,9 +16,5 @@ WORKDIR /app
 COPY . /app/
 
 RUN pip install -e .[dev]
-
-RUN jupyter contrib nbextension install && \
-   jupyter nbextension install jupytext --py && \
-   jupyter nbextension enable jupytext --py
 
 USER ${DOCKER_USER:-1000}

--- a/docs/examples.py
+++ b/docs/examples.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.13.8
+#       jupytext_version: 1.16.2
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python
@@ -38,6 +38,7 @@ from os import path
 import numpy as np
 import pandas as pd
 from fcmeans import FCM
+from kmedoids import KMedoids
 from matplotlib import pyplot as plt
 from sklearn.cluster import (
     DBSCAN,
@@ -47,7 +48,6 @@ from sklearn.cluster import (
     SpectralClustering,
 )
 from sklearn.mixture import GaussianMixture
-from sklearn_extra.cluster import KMedoids
 
 from multicons import MultiCons
 from multicons.utils import jaccard_similarity
@@ -106,7 +106,10 @@ cassini_train_data.plot.scatter(
 )
 
 # PAM
-base_clusterings.append(KMedoids(n_clusters=3).fit_predict(cassini_train_data))
+base_clusterings.append(
+    KMedoids(3, metric="euclidean", method="pam")
+    .fit_predict(cassini_train_data.to_numpy())
+)
 cassini_train_data.plot.scatter(
     title="PAM", ax=axes[1, 2], c=base_clusterings[-1], **common_kwargs
 )
@@ -320,7 +323,10 @@ gaussian_train_data.plot.scatter(
 )
 
 # PAM (3 clusters)
-base_clusterings.append(KMedoids(n_clusters=3).fit_predict(gaussian_train_data))
+base_clusterings.append(
+    KMedoids(3, metric="euclidean", method="pam")
+    .fit_predict(gaussian_train_data.to_numpy())
+)
 gaussian_train_data.plot.scatter(
     title="PAM (3 clusters)", ax=axes[2, 0], c=base_clusterings[-1], **common_kwargs
 )

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,9 @@ classifiers =
     Natural Language :: English
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 
 [options]
 include_package_data = True
@@ -36,25 +39,24 @@ python_requires = >= 3.9
 
 [options.extras_require]
 dev =
-    bandit==1.7.5
-    black==23.3.0
-    flake8==6.0.0
-    fuzzy-c-means==1.7.0
-    isort==5.12.0
-    jupyterlab==3.6.3
-    jupyter_contrib_nbextensions==0.7.0
-    jupytext==1.14.5
-    matplotlib==3.7.1
-    mkdocs==1.4.2
-    mkdocs-jupyter==0.24.1
-    mkdocs-material==9.1.6
-    mkdocstrings[python]==0.21.2
-    pylint==2.17.2
-    pytest==7.3.0
-    pytest-cov==4.0.0
-    scikit-learn-extra==0.3.0
+    bandit==1.7.8
+    black==24.4.2
+    flake8==7.0.0
+    fuzzy-c-means==1.7.2
+    isort==5.13.2
+    jupyterlab==4.1.8
+    jupytext==1.16.2
+    kmedoids==0.5.1
+    matplotlib==3.8.4
+    mkdocs==1.6.0
+    mkdocs-jupyter==0.24.7
+    mkdocs-material==9.5.21
+    mkdocstrings[python]==0.25.1
+    pylint==3.1.0
+    pytest==8.2.0
+    pytest-cov==5.0.0
 ci =
-    twine==4.0.2
+    twine==5.0.0
 
 [options.packages.find]
 where = src

--- a/src/multicons/consensus.py
+++ b/src/multicons/consensus.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=unused-argument
 
+import numpy as np
 import pandas as pd
 import scipy.sparse as sp
 
@@ -189,7 +190,7 @@ def consensus_function_14(bi_clust: list[set], merging_threshold: float = 0.5):
         if bi_clust_size == 1:
             return
         intersection_matrix = pd.DataFrame(
-            columns=range(bi_clust_size), index=range(bi_clust_size), dtype=int
+            columns=range(bi_clust_size), index=range(bi_clust_size), dtype=float
         )
 
         for i in range(bi_clust_size - 1):
@@ -221,22 +222,22 @@ def consensus_function_14(bi_clust: list[set], merging_threshold: float = 0.5):
             i = pointer.iloc[k, 0]
             j = pointer.iloc[k, 1]
             value = intersection_matrix.iloc[i, j]
-            if value is None:
+            if np.isnan(value):
                 continue
             if value >= merging_threshold:
                 bi_clust[i] = bi_clust[i].union(bi_clust[j])
                 bi_clust[j] = set()
-                intersection_matrix.iloc[i, :] = None
-                intersection_matrix.iloc[:, j] = None
+                intersection_matrix.iloc[i, :] = np.nan
+                intersection_matrix.iloc[:, j] = np.nan
                 continue
             if len(bi_clust[i]) <= len(bi_clust[j]):
                 bi_clust[j] = bi_clust[j] - bi_clust[i]
-                intersection_matrix.iloc[j, :] = None
-                intersection_matrix.iloc[:, j] = None
+                intersection_matrix.iloc[j, :] = np.nan
+                intersection_matrix.iloc[:, j] = np.nan
                 continue
             bi_clust[i] = bi_clust[i] - bi_clust[j]
-            intersection_matrix.iloc[i, :] = None
-            intersection_matrix.iloc[:, i] = None
+            intersection_matrix.iloc[i, :] = np.nan
+            intersection_matrix.iloc[:, i] = np.nan
 
 
 def consensus_function_15(bi_clust: list[set], merging_threshold: float = 0.5):
@@ -247,7 +248,7 @@ def consensus_function_15(bi_clust: list[set], merging_threshold: float = 0.5):
     if bi_clust_size == 1:
         return
     intersection_matrix = pd.DataFrame(
-        0, columns=range(bi_clust_size), index=range(bi_clust_size), dtype=int
+        0, columns=range(bi_clust_size), index=range(bi_clust_size), dtype=float
     )
     for i in range(bi_clust_size - 1):
         bi_clust_i = bi_clust[i]

--- a/src/multicons/core.py
+++ b/src/multicons/core.py
@@ -176,12 +176,12 @@ class MultiCons(BaseEstimator):
                 arrays where each array represents one clustering solution
                 (base clusterings), or a Dataframe representing a binary membership
                 matrix.
-            y: Ignored. Not used, present here for API consistency by convention.
-            sample_weight: Ignored. Not used, present here for API consistency by
+            y (any): Ignored. Not used, present here for API consistency by convention.
+            sample_weight (any): Ignored. Not used, present here for API consistency by
                 convention.
 
         Returns:
-            self: Returns the (fitted) instance itself.
+            self (MultiCons): Returns the (fitted) instance itself.
         """
 
         if isinstance(X, pd.DataFrame):

--- a/src/multicons/core.py
+++ b/src/multicons/core.py
@@ -80,8 +80,9 @@ class MultiCons(BaseEstimator):
             numeric score (indicating how similar the clustering solutions are).
         merging_threshold (float): Specifies the minimum required ratio (calculated from
             the intersection between two sets over the size of the smaller set) for
-            which the `consensus_function` should merge two sets. Only applies to
-            `consensus_function_12`.
+            which the `consensus_function` should merge two sets. Applies to
+            `consensus_function_12`, `consensus_function_13`, `consensus_function_14`
+            and `consensus_function_15`.
         optimize_label_names (bool): Indicates whether the label assignment of
             the clustering partitions should be optimized to maximize the similarity
             measure score (using the Hungarian algorithm). By default set to `False` as

--- a/tests/test_consensus.py
+++ b/tests/test_consensus.py
@@ -7,6 +7,7 @@ from multicons import (
     consensus_function_12,
     consensus_function_13,
     consensus_function_14,
+    consensus_function_15,
 )
 
 
@@ -94,4 +95,25 @@ def test_consensus_consensus_function_14(value, expected):
     """Tests the consensus_function_14 should produce the expected value."""
 
     consensus_function_14(value)
+    assert value == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        # A unique cluster remains unique
+        ([{1}], [{1}]),
+        # Clusters that are subsets are removed
+        ([{1, 2}, {1}], [{1, 2}]),
+        ([{1, 2}, {1, 2, 3}], [{1, 2, 3}]),
+        # Clusters that are intersections with a ratio higher than MT are merged
+        ([{1, 2, 3}, {2, 3, 4}, {5}], [{1, 2, 3, 4}, {5}]),
+        # Clusters that are intersections with a ration lower than MT are split
+        ([{1, 2, 3}, {3, 4, 5}, {6}], [{1, 2, 3}, {4, 5}, {6}]),
+        ([{1, 2, 3, 4}, {4, 5, 6}, {7}], [{1, 2, 3}, {4, 5, 6}, {7}]),
+    ],
+)
+def test_consensus_consensus_function_15(value, expected):
+    """Tests the consensus_function_15 should produce the expected value."""
+    consensus_function_15(value)
     assert value == expected


### PR DESCRIPTION
### Purpose

The dtype of the `intersection_matrix` used in consensus functions 14 and 15 was wrongly set to `int` which causes a pandas warning about incompatible dtypes.

### Proposal

- [x] set the `intersection_matrix` dtype to float
- [x] replace the `None` usage with `np.nan`.